### PR TITLE
Fix replacing multiple instances of same interpolation key

### DIFF
--- a/lib/express-translate.js
+++ b/lib/express-translate.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var quotemeta = require('quotemeta');
 var extend = require('obj-extend');
 
 function ExpressTranslate (settings) {
@@ -54,7 +55,8 @@ ExpressTranslate.prototype.interpolate = function (string, interpolations) {
   var labels = Object.getOwnPropertyNames(interpolations);
   labels.forEach(function (label) {
     var intLabel = intPrefix + label + intSuffix;
-    string = string.replace(intLabel, interpolations[label]);
+    var intPattern = new RegExp(quotemeta(intLabel), 'g');
+    string = string.replace(intPattern, interpolations[label]);
   });
   return string;
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   ],
   "main": "lib/express-translate",
   "dependencies": {
-    "obj-extend": "~0.1.0"
+    "obj-extend": "~0.1.0",
+    "quotemeta": "0.0.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",

--- a/test/express-translate.js
+++ b/test/express-translate.js
@@ -38,4 +38,13 @@ describe('Loading a page that is translated with express-translate', function ()
       expect(this.body).to.eql('<p>Hello World</p><p>Hello Joe</p>');
     });
   });
+
+  describe('when the translation has multiple placeholder keys of the same name', function () {
+    fixedServer.run(['GET 200 /multiple-keys']);
+    httpUtils.save('http://localhost:1337/multiple-keys');
+
+    it('should interpolate values into both placeholders', function () {
+      expect(this.body).to.eql('<p>You get a prize and you get a prize</p>');
+    });
+  });
 });

--- a/test/fixtures/fixed-server/index.js
+++ b/test/fixtures/fixed-server/index.js
@@ -70,3 +70,16 @@ exports['GET 200 /#locale-key'] = {
     }
   ]
 };
+
+exports['GET 200 /multiple-keys'] = {
+  method: 'get',
+  route: '/multiple-keys',
+  response: [
+    serverSetup,
+    setReqLocale('en'),
+    expressTranslateSetup(),
+    function (req, res) {
+      res.render('multiple');
+    }
+  ]
+};

--- a/test/fixtures/templates/multiple.jade
+++ b/test/fixtures/templates/multiple.jade
@@ -1,0 +1,1 @@
+p= t('you_get_a', {label: 'prize'})

--- a/test/fixtures/translations.js
+++ b/test/fixtures/translations.js
@@ -1,5 +1,6 @@
 module.exports = {
   en: {
-    hello: 'Hello ${name}'
+    hello: 'Hello ${name}',
+    you_get_a: 'You get a ${label} and you get a ${label}'
   }
 };


### PR DESCRIPTION
Adds in quotemeta module for escaping the key for use in a global search regex

Fixes #2 

@twolfson 
