### PR TITLE
Escape translations and interpolated values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # express-translate [![Build Status](https://travis-ci.org/uber/express-translate.png?branch=master)](https://travis-ci.org/uber/express-translate)
 
-Add simple translation support to Express
+Adds translation support to [Express](http://expressjs.com/) by exposing a `t()`
+function to both the `req` object and your views (using `res.locals`). It will
+translate keys specified in an object mapping of `key => translation string` for
+the languages that you specify. String interpolation is supported and all
+[malicious content](#solved-xss-vulnerabilities) is html-escaped by default.
 
 ## Installation
 
@@ -10,17 +14,18 @@ npm install express-translate
 
 ## Usage
 
-Initialize the middleware with:
+First, you'll want to instantiate express-translate:
 
 ``` js
-var express = require('express'),
-    ExpressTranslate = require('express-translate'),
-    app = express();
+var express = require('express');
+var ExpressTranslate = require('express-translate');
+var app = express();
 
 var expressTranslate = new ExpressTranslate();
 ```
 
-You'll then want to add a language or two to the translator:
+You'll then want to add a language or two to the translator. Translations are
+stored in an object mapping of `key => translation string`:
 
 ``` js
 expressTranslate.addLanguage('en', { hello: 'Hello ${name}' });
@@ -33,27 +38,145 @@ app.use(expressTranslate.middleware());
 ```
 
 By default, the middleware will read the current locale from `req.locale`; you
-can alter this behavior by setting the `localeKey` option described below.
-Then, within your code, you can translate a key using the translate function
-at `req.t()` or within your template, like so:
+can alter this behavior by setting the `localeKey` option described below. A
+locale **must be specified** on the `req` object in order for express-translate
+to know which language it should translate the keys in. The locale must be the
+same as those languages added to express-translate with `addLanguage()`.
+
+Within your code, you can translate a key using the translate function
+at `req.t()` or within your template. String interpolation with `key => value`
+pairs are supported:
 
 ``` jade
 h1= t('hello', { name: 'Joe' });
 ```
 
+All html within the translations and interpolated values will be escaped. If
+you wouldn't like to escape the html within an interpolated value, use the
+`whitelistedKeys` option, passing an array of label names to disregard during escaping:
+
+``` jade
+h1= t('hello', { name: '<strong>Joe</strong>' }, { whitelistedKeys: ['name'] });
+```
+
 ## Options
 
-#### localeKey
+#### Constructor Options
 
-Specifies the key on the request object the locale can be found. Defaults
-to `locale`.
+``` js
+new ExpressTranslate(options);
+```
 
-#### interpolationPrefix
+Pass an object to express-translate on instantiation with any of the following options:
 
-Specifies the prefix of the interpolation label for replacing content within
-the string. Defaults to `${`.
+- **localeKey** `String` Specifies the key on the request object the locale can
+be found. Defaults to `locale`.
+- **interpolationPrefix** `String` Specifies the prefix of the interpolation
+key used to replace content within the string. Defaults to `${`.
+- **interpolationSuffix** `String` Specifies the suffix of the interpolation
+key used to replace content within the string. Defaults to `}`.
 
-#### interpolationSuffix
+#### `expressTranslate.addLanguage(code, translations)`
 
-Specifies the suffix of the interpolation label for replacing content within
-the string. Defaults to `}`.
+Adds an object of `key => translation string` to the translator for the specified
+language.
+
+- **code** `String` Specifies the locale code the translations are for (e.g. `en`).
+- **translations** `Object` An object mapping of `key` to `translation string`
+for the specified locale (e.g. `{ hello: 'Hello ${name}' }`).
+
+#### `expressTranslate.addLanguages(codeTranslations)`
+
+Helper for adding multiple languages in one go.
+
+- **codeTranslations** `Object` An object mapping of `locale` to `translations object`
+(e.g. `{ en: { hello: '${name}'} }`)
+
+#### `req.t(key, interpolations, options)`
+
+Translates the key with the language specified at `req.locale`.
+
+- **key** `String` The key that you would like to translate (from the translations
+object added with `addLanguage()`)
+- **interpolations** `Object` An object mapping a key in the translation string
+that should be replaced with the associated value. Values are html-escaped by
+default; you can whitelist a key by using the `whitelistedKeys` option.
+- **options** `Object` Options defined below:
+  - **whitelistedKeys** `Array` An array of keys used for interpolation that should
+  not be html-escaped by default
+
+## Solved XSS Vulnerabilities
+
+`express-translate` html-escapes translation strings, interpolation keys, and
+interpolation values to prevent the following possible XSS vulnerabilities:
+
+#### Malicious translations
+
+If your translations are performed by malicious translators, they could contain
+XSS attacks:
+
+``` jade
+// Define an translation with dynamic HTML content
+!= t('welcome', {welcome_link: '<a href="/">' + user.name + '</a>'})
+
+// Inside a translation
+Hello <script>alert(1)</script>! Access your dashboard via ${welcome_link}
+```
+
+We prevent this by escaping the entire string:
+
+``` jade
+Hello &lt;script&gt;alert(1)&lt;/script&gt;! Access your dashboard via ${welcome_link}
+```
+
+#### Malicious keys
+
+If the malicious translators are smart, then they can provide a bad key which
+will not get replaced.
+
+``` jade
+Hello ${<script>alert(1)</script>}! Access your dashboard via ${welcome_link}
+```
+
+We prevent this by escaping the entire string:
+
+``` jade
+Hello ${&lt;script&gt;alert(1)&lt;/script&gt;}! Access your dashboard via ${welcome_link}
+```
+
+#### Malicious values
+
+If the end user is being malicious, then they can provide a malicious value:
+
+``` jade
+// Normal translation execution
+!= t('welcome', {welcome_link: '<a href="/">' + user.name + '</a>'})
+Hello! Access your dashboard via ${welcome_link}
+
+// With XSS attack
+var user = {name: '<script>alert(1)</script>'};
+// Hello! Access your dashboard via <a href="/"><script>alert(1)</script></a>
+```
+
+We prevent against this by escaping every value:
+
+``` jade
+Hello! Access your dashboard via &lt;a href=&quot;/&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;/a&gt;
+```
+
+Unfortunately, this has undesired side effects with HTML, so we provide a way
+to trust specific interpolated values using the `whitelistedKeys` option:
+
+``` jade
+// Translate welcome link
+- var welcome_link_text = t('welcome_link_text', {name: user.name})
+
+// Translate welcome message
+!= t('welcome', {welcome_link: '<a href="/">' + welcome_link_text + '</a>'}, {whitelistedKeys: ['welcome_link']})
+```
+
+yielding:
+
+``` jade
+Hello! Access your dashboard via <a href="/">&lt;script&gt;alert(1)&lt;/script&gt;</a>
+```

--- a/lib/express-translate.js
+++ b/lib/express-translate.js
@@ -1,6 +1,6 @@
-var fs = require('fs');
-var quotemeta = require('quotemeta');
+var escapeHtml = require('escape-html');
 var extend = require('obj-extend');
+var quotemeta = require('quotemeta');
 
 function ExpressTranslate (settings) {
   this.translations = {};
@@ -16,7 +16,7 @@ module.exports = ExpressTranslate;
 /**
  * Adds key => value translations by language code to the translator
  * @param {String} code Language code (from req.locale)
- * @param {Object} translations A hash of translation strings keyed by label
+ * @param {Object} translations A hash of translation strings with associated key
  * @return {Object} this
  */
 ExpressTranslate.prototype.addLanguage = function (code, translations) {
@@ -33,30 +33,52 @@ ExpressTranslate.prototype.addLanguage = function (code, translations) {
 ExpressTranslate.prototype.addLanguages = function (codeTranslations) {
   var self = this;
   var codes = Object.getOwnPropertyNames(codeTranslations);
-  codes.forEach(function (code) {
+  codes.forEach(function addLanguageTranslations (code) {
     self.addLanguage(code, codeTranslations[code]);
   });
   return this;
 };
 
 /**
- * Substitutes the interpolation labels into a string with their
+ * Substitutes the interpolation keys into a string with their
  * corresponding values
- * @param {String} string The string with interpolation labels to be replaced
- * @param {Object} interpolations A hash of values keyed by label to replace
+ * @param {String} string The string with interpolation keys to be replaced
+ * @param {Object} interpolations A hash of keys => values to replace
  * in the string
  * @return {String} The altered string
  */
-ExpressTranslate.prototype.interpolate = function (string, interpolations) {
-  string = string || '';
+ExpressTranslate.prototype.interpolate = function (string, interpolations, options) {
   interpolations = interpolations || {};
-  var intPrefix = this.settings.interpolationPrefix;
-  var intSuffix = this.settings.interpolationSuffix;
-  var labels = Object.getOwnPropertyNames(interpolations);
-  labels.forEach(function (label) {
-    var intLabel = intPrefix + label + intSuffix;
-    var intPattern = new RegExp(quotemeta(intLabel), 'g');
-    string = string.replace(intPattern, interpolations[label]);
+  options = options || {};
+
+  // Escape any html within the translation string
+  string = escapeHtml(string || '');
+
+  // Escape the interpolation prefix/suffix settings so that they can still
+  // match the now-escaped translation string
+  var intPrefix = escapeHtml(this.settings.interpolationPrefix);
+  var intSuffix = escapeHtml(this.settings.interpolationSuffix);
+
+  // Store the whitelisted keys on an object for performant searches
+  var whitelistedKeys = {};
+  options.whitelistedKeys = options.whitelistedKeys || [];
+  options.whitelistedKeys.forEach(function storeWhitelistedKeys (key) {
+    whitelistedKeys[key] = true;
+  });
+
+  // Interpolate the values into the translation string
+  var keys = Object.getOwnPropertyNames(interpolations);
+  keys.forEach(function interpolateTranslationValues (key) {
+    // Create regex key pattern for replacement
+    var intKey = intPrefix + key + intSuffix;
+    var intPattern = new RegExp(quotemeta(intKey), 'g');
+
+    // Escape html within the values unless key is specifically whitelisted
+    var value = interpolations[key];
+    var intValue = whitelistedKeys[key] ? value : escapeHtml(value);
+
+    // Replace the keys with the interpolation values
+    string = string.replace(intPattern, intValue);
   });
   return string;
 };
@@ -70,10 +92,10 @@ ExpressTranslate.prototype.interpolate = function (string, interpolations) {
  * @return {String} The translated string or the original key (if no
  * translations present for that language)
  */
-ExpressTranslate.prototype.translate = function (lang, key, interpolations) {
+ExpressTranslate.prototype.translate = function (lang, key, interpolations, options) {
   if (lang && this.translations[lang] && this.translations[lang][key]) {
     var translation = this.translations[lang][key];
-    return this.interpolate(translation, interpolations);
+    return this.interpolate(translation, interpolations, options);
   }
   return key;
 };
@@ -86,8 +108,8 @@ ExpressTranslate.prototype.translate = function (lang, key, interpolations) {
  */
 ExpressTranslate.prototype.translator = function (lang) {
   var self = this;
-  return function expressTranslate (key, interpolations) {
-    return self.translate(lang, key, interpolations);
+  return function expressTranslate (key, interpolations, options) {
+    return self.translate(lang, key, interpolations, options);
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
   ],
   "main": "lib/express-translate",
   "dependencies": {
-    "obj-extend": "~0.1.0",
-    "quotemeta": "0.0.0"
+    "escape-html": "~1.0.1",
+    "quotemeta": "0.0.0",
+    "obj-extend": "~0.1.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",

--- a/test/fixtures/fixed-server/index.js
+++ b/test/fixtures/fixed-server/index.js
@@ -83,3 +83,58 @@ exports['GET 200 /multiple-keys'] = {
     }
   ]
 };
+
+exports['GET 200 /escape-values'] = {
+  method: 'get',
+  route: '/escape-values',
+  response: [
+    serverSetup,
+    setReqLocale('en'),
+    expressTranslateSetup(),
+    function (req, res) {
+      res.render('escape-values');
+    }
+  ]
+};
+
+exports['GET 200 /escape-key'] = {
+  method: 'get',
+  route: '/escape-key',
+  response: [
+    serverSetup,
+    setReqLocale('en'),
+    expressTranslateSetup(),
+    function (req, res) {
+      res.render('escape-key');
+    }
+  ]
+};
+
+exports['GET 200 /escape-translation'] = {
+  method: 'get',
+  route: '/escape-translation',
+  response: [
+    serverSetup,
+    setReqLocale('en'),
+    expressTranslateSetup(),
+    function (req, res) {
+      res.render('escape-translation');
+    }
+  ]
+};
+
+exports['GET 200 /interpolation-setting'] = {
+  method: 'get',
+  route: '/interpolation-setting',
+  response: [
+    serverSetup,
+    setReqLocale('en'),
+    expressTranslateSetup({
+      interpolationPrefix: '<',
+      interpolationSuffix: '>'
+    }),
+    function (req, res) {
+      res.render('interpolation-setting');
+    }
+  ]
+};

--- a/test/fixtures/templates/escape-key.jade
+++ b/test/fixtures/templates/escape-key.jade
@@ -1,0 +1,1 @@
+p!= t('malicious_key', {name: 'World'})

--- a/test/fixtures/templates/escape-translation.jade
+++ b/test/fixtures/templates/escape-translation.jade
@@ -1,0 +1,2 @@
+p!= t('malicious', {name: '<script>alert("hi")</script>'})
+p!= t('malicious', {name: '<script>alert("bye")</script>'}, {whitelistedKeys: ['name']})

--- a/test/fixtures/templates/escape-values.jade
+++ b/test/fixtures/templates/escape-values.jade
@@ -1,0 +1,2 @@
+p!= t('hello', {name: '<script>alert("hi")</script>'})
+p!= t('hello', {name: '<script>alert("bye")</script>'}, {whitelistedKeys: ['name']})

--- a/test/fixtures/templates/interpolation-setting.jade
+++ b/test/fixtures/templates/interpolation-setting.jade
@@ -1,0 +1,1 @@
+p= t('hello_alt', { name: 'World' })

--- a/test/fixtures/translations.js
+++ b/test/fixtures/translations.js
@@ -1,6 +1,9 @@
 module.exports = {
   en: {
     hello: 'Hello ${name}',
-    you_get_a: 'You get a ${label} and you get a ${label}'
+    hello_alt: 'Hello <name>',
+    you_get_a: 'You get a ${label} and you get a ${label}',
+    malicious: '<script>alert("hi")</script> ${name}',
+    malicious_key: 'Hello ${<script>alert("hi")</script>}'
   }
 };


### PR DESCRIPTION
We should always assume that translations and the interpolated values
that are placed into that translation are malicious. This PR will escape
any html within these by default. You may unescape interpolated values
using the `unescape` option.
